### PR TITLE
Fix clock settings for receive

### DIFF
--- a/stm32f469i-discovery/README.md
+++ b/stm32f469i-discovery/README.md
@@ -64,6 +64,4 @@ Just right click on `chirp-sdk-stm32f469i-discovery-demo Debug.launch` -> `Debug
 
 ## Known issues and limitations
 
- * Unfortunately, the audio drivers provided by ST through the HAL are not properly working. This leads to the decoding of payloads not working.
-
  * For some reason, the theoretical conversion form float to unsigned short doesn't work well. To avoid this issue, the float value is moved from being between 0 and 2 to being between 1 and 3. This create some discontinuities in the buffer containing the unsigned short values but the audio output is correct.

--- a/stm32f469i-discovery/include/main.h
+++ b/stm32f469i-discovery/include/main.h
@@ -4,6 +4,10 @@
 // Here to provide LCD colors in application.c
 #include "stm32469i_discovery_lcd.h"
 
+bool init_audio_input(void);
+
+bool init_audio_output(void);
+
 void error_handler(const char *function, char *file, int line);
 
 void set_screen_color(uint32_t color);

--- a/stm32f469i-discovery/src/application.c
+++ b/stm32f469i-discovery/src/application.c
@@ -132,6 +132,7 @@ void on_received_callback(void *chirp, uint8_t *payload, size_t length, uint8_t 
 		itoa((int) length, str_length, 10);
 		display_message(hexa_string, LCD_COLOR_BLACK);
 		display_message(str_length, LCD_COLOR_BLACK);
+		printf("Received: %s\n", hexa_string);
 	}
 	else
 	{
@@ -185,6 +186,10 @@ void setup(uint32_t sample_rate)
 	if (err != CHIRP_SDK_OK)
 		chirp_error_handler(err);
 
+	err = chirp_sdk_set_frequency_correction(chirp, 0.9976720f);
+	if (err != CHIRP_SDK_OK)
+		chirp_error_handler(err);
+
 	err = chirp_sdk_start(chirp);
 	if (err != CHIRP_SDK_OK)
 		chirp_error_handler(err);
@@ -210,5 +215,4 @@ void loop(float *buffer, uint16_t blocksize)
 	error = chirp_sdk_process_output(chirp, buffer, blocksize);
 	if (error != CHIRP_SDK_OK)
 		chirp_error_handler(error);
-
 }


### PR DESCRIPTION
**Who:** Me
**Why:** Receive not working
**What:**

- The RCC->PLLI2SCFGR register is altered because the setup function for the output audio reconfigures it, so these changes reinitialise the clocks each time the mode is changed. 
- Added frequency correction which works at 16kHz.