### PR TITLE
Add options for other sample rates

### DIFF
--- a/stm32f469i-discovery/Drivers/BSP/STM32469I-Discovery/stm32469i_discovery_audio.h
+++ b/stm32f469i-discovery/Drivers/BSP/STM32469I-Discovery/stm32469i_discovery_audio.h
@@ -215,7 +215,7 @@
 #define AUDIO_TIMEOUT                       ((uint8_t)2)
 
 /* AudioFreq * DataSize (2 bytes) * NumChannels (Stereo: 2) */
-#define DEFAULT_AUDIO_IN_FREQ               I2S_AUDIOFREQ_16K
+#define DEFAULT_AUDIO_IN_FREQ               I2S_AUDIOFREQ_44K
 #define DEFAULT_AUDIO_IN_BIT_RESOLUTION     ((uint8_t)16)
 #define DEFAULT_AUDIO_IN_CHANNEL_NBR        ((uint8_t)2) /* Mono = 1, Stereo = 2 */
 #define DEFAULT_AUDIO_IN_VOLUME             ((uint16_t)64)
@@ -318,17 +318,17 @@ void    BSP_AUDIO_IN_Error_Callback(void);
 
 /* These function can be modified in case the current settings (e.g. DMA stream)
    need to be changed for specific application needs */
-void  BSP_AUDIO_IN_ClockConfig(I2S_HandleTypeDef *hi2s, void *Params);   
+void  BSP_AUDIO_IN_ClockConfig(I2S_HandleTypeDef *hi2s, void *Params);
 void  BSP_AUDIO_IN_MspInit(I2S_HandleTypeDef *hi2s, void *Params);
 void  BSP_AUDIO_IN_MspDeInit(I2S_HandleTypeDef *hi2s, void *Params);
 
 /**
   * @}
-  */ 
+  */
 
 /**
   * @}
-  */ 
+  */
 
 /**
   * @}

--- a/stm32f469i-discovery/README.md
+++ b/stm32f469i-discovery/README.md
@@ -64,4 +64,7 @@ Just right click on `chirp-sdk-stm32f469i-discovery-demo Debug.launch` -> `Debug
 
 ## Known issues and limitations
 
+ * To change the sample rate from 16kHz, you will need to update the `DEFAULT_AUDIO_IN_FREQ` define in
+ [stm32f468i_discovery_audio.h](./Drivers/STM32F$69I-Discovery/stm32f469_discovery_audio.h).
+
  * For some reason, the theoretical conversion form float to unsigned short doesn't work well. To avoid this issue, the float value is moved from being between 0 and 2 to being between 1 and 3. This create some discontinuities in the buffer containing the unsigned short values but the audio output is correct.

--- a/stm32f469i-discovery/src/application.c
+++ b/stm32f469i-discovery/src/application.c
@@ -44,7 +44,7 @@
 #include "main.h"
 
 #define CORRECTION_16K		0.9976720f
-#define CORRECTION_44K		1.0038439f
+#define CORRECTION_44K		1.0004028f
 #define CORRECTION_48K		1.0196455f
 
 /*
@@ -190,13 +190,20 @@ void setup(uint32_t sample_rate)
 	if (err != CHIRP_SDK_OK)
 		chirp_error_handler(err);
 
-	if (sample_rate == 16000) {
+	if (sample_rate == 16000)
+	{
 		err = chirp_sdk_set_frequency_correction(chirp, CORRECTION_16K);
-	} else if (sample_rate == 44100) {
+	}
+	else if (sample_rate == 44100)
+	{
 		err = chirp_sdk_set_frequency_correction(chirp, CORRECTION_44K);
-	} else if (sample_rate == 48000) {
+	}
+	else if (sample_rate == 48000)
+	{
 		err = chirp_sdk_set_frequency_correction(chirp, CORRECTION_48K);
-	} else {
+	}
+	else
+	{
 		printf("Sample rate %ld not supported\n", sample_rate);
 	}
 	if (err != CHIRP_SDK_OK)

--- a/stm32f469i-discovery/src/application.c
+++ b/stm32f469i-discovery/src/application.c
@@ -43,6 +43,10 @@
  */
 #include "main.h"
 
+#define CORRECTION_16K		0.9976720f
+#define CORRECTION_44K		1.0038439f
+#define CORRECTION_48K		1.0196455f
+
 /*
  * Global pointer to the SDK structure. This is global as this pointer is
  * needed when processing the audio in the loop() function.
@@ -186,7 +190,15 @@ void setup(uint32_t sample_rate)
 	if (err != CHIRP_SDK_OK)
 		chirp_error_handler(err);
 
-	err = chirp_sdk_set_frequency_correction(chirp, 0.9976720f);
+	if (sample_rate == 16000) {
+		err = chirp_sdk_set_frequency_correction(chirp, CORRECTION_16K);
+	} else if (sample_rate == 44100) {
+		err = chirp_sdk_set_frequency_correction(chirp, CORRECTION_44K);
+	} else if (sample_rate == 48000) {
+		err = chirp_sdk_set_frequency_correction(chirp, CORRECTION_48K);
+	} else {
+		printf("Sample rate %ld not supported\n", sample_rate);
+	}
 	if (err != CHIRP_SDK_OK)
 		chirp_error_handler(err);
 

--- a/stm32f469i-discovery/src/main.c
+++ b/stm32f469i-discovery/src/main.c
@@ -33,16 +33,21 @@ void SystemClock_Config(void);
 void setup(uint32_t sample_rate);
 void loop(float *buffer, uint16_t blocksize);
 
-#define VOLUME 100
-#define SAMPLE_RATE 16000
-#define PDM_BUFFER_SIZE INTERNAL_BUFF_SIZE
-#define SHORT_BUFFER_SIZE (PCM_OUT_SIZE * 10)
+/*
+ * Important - to change the sample rate you also need to change
+ * DEFAULT_AUDIO_IN_FREQ to the required sample rate in
+ * Drivers/BSP/STM32F$69I-Discovery/stm32f469_discovery_audio.h.
+ */
+#define VOLUME 					100
+#define SAMPLE_RATE 			16000
+#define PDM_BUFFER_SIZE 		INTERNAL_BUFF_SIZE
+#define SHORT_BUFFER_SIZE 		(PCM_OUT_SIZE * 2)
 
 /*
  * The float buffer is a quarter the short buffer because it will represent half
  * of the short buffer (division by 2) in mono samples (another division by 2).
  */
-#define FLOAT_BUFFER_SIZE (SHORT_BUFFER_SIZE / 4)
+#define FLOAT_BUFFER_SIZE		(SHORT_BUFFER_SIZE / 4)
 
 /*
  * Used to keep track of the state of buffers.
@@ -408,7 +413,6 @@ int main(void)
 	}
 
 	printf("Audio initialised.\n");
-
 
 	while (true)
 	{

--- a/stm32f469i-discovery/src/main.c
+++ b/stm32f469i-discovery/src/main.c
@@ -39,9 +39,9 @@ void loop(float *buffer, uint16_t blocksize);
  * Drivers/BSP/STM32F$69I-Discovery/stm32f469_discovery_audio.h.
  */
 #define VOLUME 					100
-#define SAMPLE_RATE 			16000
+#define SAMPLE_RATE 			44100
 #define PDM_BUFFER_SIZE 		INTERNAL_BUFF_SIZE
-#define SHORT_BUFFER_SIZE 		(PCM_OUT_SIZE * 2)
+#define SHORT_BUFFER_SIZE 		(PCM_OUT_SIZE * 10)
 
 /*
  * The float buffer is a quarter the short buffer because it will represent half
@@ -370,8 +370,9 @@ void process_audio(void)
 			// Convert a mono float buffer into half of a stereo short one.
 			for (size_t i = 0; i < FLOAT_BUFFER_SIZE; i++)
 			{
-				short_play_buffer[play_buffer_offset + i * 2] = float_to_uint16(float_buffer[i]);
-				short_play_buffer[play_buffer_offset + i * 2 + 1] = float_to_uint16(float_buffer[i]);
+				uint16_t value = float_to_uint16(float_buffer[i]);
+				short_play_buffer[play_buffer_offset + i * 2] = value;
+				short_play_buffer[play_buffer_offset + i * 2 + 1] = value;
 			}
 
 			play_buffer_state = BUFFER_STATE_EMPTY;

--- a/stm32f746g-discovery/Makefile
+++ b/stm32f746g-discovery/Makefile
@@ -99,7 +99,7 @@ CFLAGS	+=	-DSTM32F746xx \
 			-g3 \
 			-Wall \
 			-mthumb \
-			-mcpu=cortex-m4 \
+			-mcpu=cortex-m7 \
 			-mfloat-abi=$(FLOAT_ABI) \
 			-mfpu=fpv4-sp-d16 \
 			-fmessage-length=0 \

--- a/stm32f746g-discovery/src/main.c
+++ b/stm32f746g-discovery/src/main.c
@@ -34,19 +34,10 @@ void SystemClock_Config(void);
 void setup(uint32_t sample_rate);
 void loop(float *buffer, uint16_t blocksize);
 
-#define VOLUME 100
-/*
- * The sample rate is higher than the one naming the config file from Chirp. It
- * doesn't matter as long as it is higher than 16kHz.
- */
-#define SAMPLE_RATE 16000
-#define SHORT_BUFFER_SIZE 2048
-
-/*
- * The float buffer is a quarter the short buffer because it will represent half
- * of the short buffer (division by 2) in mono samples (another division by 2).
- */
-#define FLOAT_BUFFER_SIZE (SHORT_BUFFER_SIZE / 4)
+#define VOLUME 				100
+#define SAMPLE_RATE 	  	44100
+#define SHORT_BUFFER_SIZE 	2048
+#define FLOAT_BUFFER_SIZE 	(SHORT_BUFFER_SIZE / 4)
 
 /*
  * Used to keep track of the state of buffers.
@@ -235,8 +226,8 @@ void BSP_AUDIO_OUT_Error_CallBack(void)
  */
 bool init_audio(void)
 {
-	if (BSP_AUDIO_IN_OUT_Init(INPUT_DEVICE_DIGITAL_MICROPHONE_2,OUTPUT_DEVICE_HEADPHONE,
-			SAMPLE_RATE, DEFAULT_AUDIO_IN_BIT_RESOLUTION,DEFAULT_AUDIO_IN_CHANNEL_NBR))
+	if (BSP_AUDIO_IN_OUT_Init(INPUT_DEVICE_DIGITAL_MICROPHONE_2, OUTPUT_DEVICE_HEADPHONE,
+			SAMPLE_RATE, DEFAULT_AUDIO_IN_BIT_RESOLUTION, DEFAULT_AUDIO_IN_CHANNEL_NBR))
 	{
 		printf("Audio IN/OUT initialisation failed.\n");
 		return false;
@@ -312,8 +303,10 @@ void process_audio(void)
 			// Convert a mono float buffer into half of a stereo short one.
 			for (size_t i = 0; i < FLOAT_BUFFER_SIZE; i++)
 			{
-				short_play_buffer[play_buffer_offset + i * 2] = float_to_uint16(float_buffer[i]);
-				short_play_buffer[play_buffer_offset + i * 2 + 1] = float_to_uint16(float_buffer[i]);
+				uint16_t value = float_to_uint16(float_buffer[i]);
+				short_play_buffer[play_buffer_offset + i * 2] = value;
+				short_play_buffer[play_buffer_offset + i * 2 + 1] = value;
+
 			}
 
 			play_buffer_state = BUFFER_STATE_EMPTY;


### PR DESCRIPTION
- Fixed bug when using other sample rates on the STM32F4, the problem was with the PDM module. The PDM buffer size is hardcoded and used by the audio driver, so we need to change the value in the header to allocate the correct buffer size. 

- STM32F4 is now detecting the correct frequencies at 44.1kHz and 48kHz, however still not decoding - perhaps not processing fast enough.

- Also set the STM32F7 project to use 44.1kHz by default now, this works for sending and receiving, and with the embedded ultrasonic protocol. 